### PR TITLE
Agregar información al hacer hover en el gráfico del commit 

### DIFF
--- a/Web Ui/src/sections/TDDCycles-Visualization/components/TDDLineChart.tsx
+++ b/Web Ui/src/sections/TDDCycles-Visualization/components/TDDLineChart.tsx
@@ -189,6 +189,11 @@ function TDDLineCharts({
                   getCommitStats()[1][context[0].dataIndex]
                 }`,
               );
+              afterBodyContent.push(
+                `Total de Cambios: ${
+                  getCommitStats()[2][context[0].dataIndex]
+                }`,
+              );
               return afterBodyContent;
             },
           },

--- a/Web Ui/src/sections/TDDCycles-Visualization/components/TDDLineChart.tsx
+++ b/Web Ui/src/sections/TDDCycles-Visualization/components/TDDLineChart.tsx
@@ -99,7 +99,7 @@ function TDDLineCharts({
   function getCommitCoverage() {
     if (filteredCommitsObject != null) {
       const coverage = filteredCommitsObject
-        .map((commit) => commit.coverage)
+        .map((commit) => (commit.coverage != 0 ? commit.coverage : 0))
         .reverse();
       return coverage;
     } else {
@@ -193,6 +193,11 @@ function TDDLineCharts({
                 `Total de Cambios: ${
                   getCommitStats()[2][context[0].dataIndex]
                 }`,
+              );
+              const coverageValue = getCommitCoverage()[context[0].dataIndex];
+              const formattedCoverage = coverageValue !== undefined && coverageValue !== null ? `${coverageValue}%` : '0%';
+              afterBodyContent.push(
+                `Cobertura: ${coverageValue === 0 ? '0%' : formattedCoverage}`,
               );
               return afterBodyContent;
             },


### PR DESCRIPTION
Agregamos el total de cambios y la información de cobertura al tooltip del gráfico al hacer hover al commit. 