### PR TITLE
Parametrización de todas las ocurrencias del API_URL en el Web UI

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -229,6 +229,7 @@ jobs:
         working-directory: Web Ui
         run: |
           echo "VITE_FIREBASE_API_KEY=${{ secrets.VITE_FIREBASE_API_KEY }}" > ./.env
+          echo "VITE_API_URL=${{ secrets.API_URL }}" >> ./.env
 
       - name: Install Dependencies
         working-directory: Web Ui

--- a/Web Ui/config.ts
+++ b/Web Ui/config.ts
@@ -1,0 +1,1 @@
+export const VITE_API = import.meta.env.VITE_API_URL;

--- a/Web Ui/jest.config.ts
+++ b/Web Ui/jest.config.ts
@@ -10,5 +10,6 @@ export default {
     "\\.(gif|ttf|eot|svg|png)$": "<rootDir>/test/__ mocks __/fileMock.js",
     "^.+\\.(css|less)$": "<rootDir>/CSSStub.js",
   },
+  setupFiles: ['<rootDir>/jest.setup.js'],
   silent: true,
 };

--- a/Web Ui/jest.setup.js
+++ b/Web Ui/jest.setup.js
@@ -1,0 +1,9 @@
+/* eslint-disable */
+
+require('dotenv').config();
+// Mock para evitar el error de Vite en los tests
+jest.mock('./config.ts', () => ({
+    VITE_API: process.env.VITE_API_URL
+}));
+
+/* eslint-enable */

--- a/Web Ui/package-lock.json
+++ b/Web Ui/package-lock.json
@@ -16,6 +16,7 @@
         "axios": "^1.5.0",
         "chart.js": "^4.4.0",
         "dayjs": "^1.11.10",
+        "dotenv": "^16.4.5",
         "express": "^4.18.2",
         "firebase": "^10.5.2",
         "jest-environment-jsdom": "^29.6.4",
@@ -5431,6 +5432,17 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ecc-jsbn": {

--- a/Web Ui/package.json
+++ b/Web Ui/package.json
@@ -22,6 +22,7 @@
     "axios": "^1.5.0",
     "chart.js": "^4.4.0",
     "dayjs": "^1.11.10",
+    "dotenv": "^16.4.5",
     "express": "^4.18.2",
     "firebase": "^10.5.2",
     "jest-environment-jsdom": "^29.6.4",

--- a/Web Ui/public/index.html
+++ b/Web Ui/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/Web Ui/src/modules/Assignments/repository/AssignmentsRepository.ts
+++ b/Web Ui/src/modules/Assignments/repository/AssignmentsRepository.ts
@@ -1,8 +1,9 @@
 import axios from "axios"; // Import Axios or your preferred HTTP library
 import { AssignmentDataObject } from "../domain/assignmentInterfaces"; // Import your assignment model
 import AssignmentsRepositoryInterface from "../domain/AssignmentsRepositoryInterface";
+import {VITE_API} from "../../../../config.ts";
 
-const API_URL = "https://tdd-lab-api-gold.vercel.app/api/assignments"; //http://localhost:3000/api/ -> https://tdd-lab-api-gold.vercel.app/api/
+const API_URL = VITE_API + "/assignments";
 
 
 class AssignmentsRepository implements AssignmentsRepositoryInterface {

--- a/Web Ui/src/modules/Groups/repository/GroupsRepository.ts
+++ b/Web Ui/src/modules/Groups/repository/GroupsRepository.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
 import { GroupDataObject } from "../domain/GroupInterface";
 import GroupsRepositoryInterface from "../domain/GroupsRepositoryInterface";
+import {VITE_API} from "../../../../config.ts";
 
-const API_URL = "https://tdd-lab-api-gold.vercel.app/api/groups"; //http://localhost:3000/api/ -> https://tdd-lab-api-gold.vercel.app/api/
+const API_URL = VITE_API + "/groups";
 
 class GroupsRepository implements GroupsRepositoryInterface {
   async getGroups(): Promise<GroupDataObject[]> {

--- a/Web Ui/src/modules/Submissions/Repository/SubmissionRepository.ts
+++ b/Web Ui/src/modules/Submissions/Repository/SubmissionRepository.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
 import { SubmissionCreationObject, SubmissionDataObject, SubmissionUpdateObject } from "../Domain/submissionInterfaces";
 import SubmissionRepositoryInterface from "../Domain/SubmissionRepositoryInterface";
+import {VITE_API} from "../../../../config.ts";
 
-const API_URL = "https://tdd-lab-api-gold.vercel.app/api/submissions"; //https://localhost:3000/api/ -> https://tdd-lab-api-gold.vercel.app/api/
+const API_URL = VITE_API + "/submissions";
 
 class SubmissionRepository implements SubmissionRepositoryInterface {
 

--- a/Web Ui/src/modules/TDDCycles-Visualization/repository/GithubAPIAdapter.ts
+++ b/Web Ui/src/modules/TDDCycles-Visualization/repository/GithubAPIAdapter.ts
@@ -4,6 +4,7 @@ import { JobDataObject } from "../domain/jobInterfaces";
 import { GithubAPIRepository } from "../domain/GithubAPIRepositoryInterface";
 import { formatDate } from '../application/GetTDDCycles';
 import axios from "axios";
+import {VITE_API} from "../../../../config.ts";
 
 export class GithubAPIAdapter implements GithubAPIRepository {
   octokit: Octokit;
@@ -11,7 +12,7 @@ export class GithubAPIAdapter implements GithubAPIRepository {
   constructor() {
     this.octokit = new Octokit();
       //auth: 'coloca tu token github para mas requests'
-    this.backAPI = "https://tdd-lab-api-gold.vercel.app/api/TDDCycles"; //https://localhost:3000/api/ -> https://tdd-lab-api-gold.vercel.app/api/
+    this.backAPI = VITE_API + "/TDDCycles"; //https://localhost:3000/api/ -> https://tdd-lab-api-gold.vercel.app/api/
   }
 
   async obtainCommitsOfRepo(

--- a/Web Ui/src/modules/User-Authentication/repository/LoginRepository.ts
+++ b/Web Ui/src/modules/User-Authentication/repository/LoginRepository.ts
@@ -1,8 +1,9 @@
 import axios from "axios"; // Import Axios or your preferred HTTP library
 import AuthDBRepositoryInterface from "../domain/LoginRepositoryInterface";
 import { UserOnDb } from "../domain/userOnDb.interface";
+import {VITE_API} from "../../../../config.ts";
 
-const API_URL = "https://tdd-lab-api-gold.vercel.app/api"; //http://localhost:3000/api/ -> https://tdd-lab-api-gold.vercel.app/api/
+const API_URL = VITE_API;
 
 class AuthRepository implements AuthDBRepositoryInterface {
   async getAccountInfo(email: string): Promise<UserOnDb> {

--- a/Web Ui/src/modules/Users/repository/UsersRepository.ts
+++ b/Web Ui/src/modules/Users/repository/UsersRepository.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
 import { UserDataObject } from "../domain/UsersInterface";
 import UsersRepositoryInterface from "../domain/UsersRepositoryInterface";
+import {VITE_API} from "../../../../config.ts";
 
-const API_URL = "https://tdd-lab-api-gold.vercel.app/api/user/users"; //http://localhost:3000/api/ -> https://tdd-lab-api-gold.vercel.app/api/
+const API_URL = VITE_API + "/user/users";
 
 class UsersRepository implements UsersRepositoryInterface {
 

--- a/Web Ui/test/modules/Groups/repository/GroupsRepository.test.ts
+++ b/Web Ui/test/modules/Groups/repository/GroupsRepository.test.ts
@@ -1,13 +1,15 @@
 import axios from 'axios';
 import GroupsRepository from '../../../../src/modules/Groups/repository/GroupsRepository';
 import { GroupDataObject } from '../../../../src/modules/Groups/domain/GroupInterface';
+import dotenv from "dotenv";
+dotenv.config();
 
 const axiosGetSpy = jest.spyOn(axios, 'get');
 const axiosPostSpy = jest.spyOn(axios, 'post');
 const axiosDeleteSpy = jest.spyOn(axios, 'delete');
 
 const repository = new GroupsRepository();
-const API_URL = 'https://tdd-lab-api-gold.vercel.app/api/groups';
+const API_URL = process.env.VITE_API_URL + '/groups';
 
 describe('GroupsRepository', () => {
   afterEach(() => {

--- a/Web Ui/test/modules/User-Authentication/repository/LoginRepository.test.ts
+++ b/Web Ui/test/modules/User-Authentication/repository/LoginRepository.test.ts
@@ -1,9 +1,11 @@
 import axios from "axios";
 import AuthRepository from "../../../../src/modules/User-Authentication/repository/LoginRepository";
 import { dbUserMock } from "../../__mocks__/Auth/userOnDbMock";
+import dotenv from 'dotenv';
+dotenv.config()
 
 // Mocking Axios to avoid actual HTTP requests
-const API_URL = "https://tdd-lab-api-gold.vercel.app/api";
+const API_URL = process.env.VITE_API_URL;
 
 jest.mock("axios");
 

--- a/Web Ui/test/modules/Users/repository/UsersRepository.test.ts
+++ b/Web Ui/test/modules/Users/repository/UsersRepository.test.ts
@@ -1,12 +1,14 @@
 import axios from 'axios';
 import UsersRepository from '../../../../src/modules/Users/repository/UsersRepository';
 import { UserDataObject } from '../../../../src/modules/Users/domain/UsersInterface';
+import dotenv from "dotenv";
+dotenv.config();
 
 const axiosGetSpy = jest.spyOn(axios, 'get');
 
 const repository = new UsersRepository();
 const axiosPutSpy = jest.spyOn(axios, 'put');
-const API_URL = 'https://tdd-lab-api-gold.vercel.app/api/user/users';
+const API_URL = process.env.VITE_API_URL + '/user/users';
 
 describe('UsersRepository', () => {
   afterEach(() => {

--- a/Web Ui/test/modules/assignments/repository/AssignmentsRepository.test.ts
+++ b/Web Ui/test/modules/assignments/repository/AssignmentsRepository.test.ts
@@ -1,6 +1,8 @@
 import AssignmentsRepository from "../../../../src/modules/Assignments/repository/AssignmentsRepository";
 import axios from "axios";
 import { assignmentInProgresDataMock } from "../../__mocks__/assignments/data/assigmentDataMock";
+import dotenv from 'dotenv';
+dotenv.config()
 
 const axiosGetSpy = jest.spyOn(axios, 'get');
 const axiosPostSpy = jest.spyOn(axios, 'post');
@@ -8,7 +10,7 @@ const axiosPutSpy = jest.spyOn(axios, 'put');
 const axiosDeleteSpy = jest.spyOn(axios, 'delete');
 
 const mockRepository = new AssignmentsRepository();
-const API_URL = 'https://tdd-lab-api-gold.vercel.app/api/assignments'
+const API_URL = process.env.VITE_API_URL + '/assignments'
 describe('Get assignments', () => {
     it('should fetch assignments successfully', async () => {
         axiosGetSpy.mockResolvedValue({ status: 200, data: assignmentInProgresDataMock });

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Se parametrizó la API_URL las ocurrencias del Web UI/src/modules/ para que sea extraida del archivo config.ts utilizando Vite, pero para que los tests pasen, se tuvo que mockear el valor de este archivo en un jest.setup.js, por una incompatibilidad de los tests con Vite; y las ocurrencias de API_URL de los tests, se parametrizó con la libreria dotenv.