### PR TITLE
se añadio archivos y funciones destinados a dar soporte al upload del tdd log

### DIFF
--- a/server/src/controllers/TDDCycles/TDDCyclesController.ts
+++ b/server/src/controllers/TDDCycles/TDDCyclesController.ts
@@ -4,10 +4,15 @@ import { IDBCommitsRepository } from "../../modules/TDDCycles/Domain/IDBCommitsR
 import { IGithubRepository } from "../../modules/TDDCycles/Domain/IGithubRepository";
 import { GetTDDCyclesUseCase } from "../../modules/TDDCycles/Application/getTDDCyclesUseCase";
 import { GetTestResultsUseCase } from "../../modules/TDDCycles/Application/getTestResultsUseCase";
+import { PostTDDLogUseCase } from "../../modules/TDDCycles/Application/postTDDLogUseCase";
+import { ITimelineEntry } from "../../modules/TDDCycles/Domain/ITimelineCommit";
+
+
 
 class TDDCyclesController {
   tddCyclesUseCase: GetTDDCyclesUseCase;
   testResultsUseCase: GetTestResultsUseCase;
+  submitTDDLogToDB: PostTDDLogUseCase;
   constructor(
     dbCommitsRepository: IDBCommitsRepository,
     dbJobsRepository: IDBJobsRepository,
@@ -20,6 +25,9 @@ class TDDCyclesController {
     this.testResultsUseCase = new GetTestResultsUseCase(
       dbJobsRepository,
       githubRepository
+    );
+    this.submitTDDLogToDB = new PostTDDLogUseCase(
+      dbJobsRepository,
     );
   }
   async getTDDCycles(req: Request, res: Response) {
@@ -56,5 +64,55 @@ class TDDCyclesController {
       return res.status(500).json({ error: "Server error" });
     }
   }
+
+  async uploadTDDLog(req: Request, res: Response) {
+    
+    try {
+      const tddLog = req.body;
+      if (!tddLog) {
+        return res.status(400).json({ error: "Choquito choquito, necesito tu TDD log, no jalo de otra." });
+      }
+      console.log("Archivo TDD log recibido", tddLog);
+      console.log("Ahora procederé a extraer los datos para insertarlos en la tabla");
+      let actualCommitSha = null;
+      let lastCommitIndex = 0;
+      const commitTimelineEntries = [];
+      //itero sobre todos los objetos del tdd log
+      for (let i = 0; i < tddLog.length; i++){
+        const entry = tddLog[i];
+        //chequeamos si el entry es un commit entry
+        if(entry.commitId){
+          actualCommitSha = entry.commitId;
+          //una vez encontrado el entry commit, chequeamos todos los commits anteriores, por lo que por ahora, hacemos otro for
+          for(let j = lastCommitIndex; j < i; j++)
+          {
+            const testEntry = tddLog[j];
+            if(testEntry.numPassedTests !== undefined && testEntry.numTotalTests !== undefined && testEntry.timestamp){
+              const color = testEntry.numPassedTests === testEntry.numTotalTests ? "green" : "red";
+              const commitTimelineEntry: ITimelineEntry = {
+                execution_id: null, 
+                commit_sha: actualCommitSha,
+                execution_timestamp: new Date(testEntry.timestamp),
+                number_of_tests: testEntry.numTotalTests,
+                passed_tests: testEntry.numPassedTests,
+                color: color,
+              };
+              commitTimelineEntries.push(commitTimelineEntry);
+            } 
+          } 
+          lastCommitIndex = i + 1;
+        }
+      }
+      console.log("Entradas para registrar en la BD:", commitTimelineEntries);
+      await this.submitTDDLogToDB.execute(commitTimelineEntries); //anadi esta linea de codigo
+
+      return res.status(200).json({ message: "Archivo TDD log procesado y registros creados", data: commitTimelineEntries });
+    } catch (error) {
+      console.error("Error al procesar el archivo TDD log:", error);
+      return res.status(500).json({ error: "Error al procesar el archivo TDD log" });
+    }
+  }
+  
+  
 }
 export default TDDCyclesController;

--- a/server/src/modules/TDDCycles/Application/postTDDLogUseCase.ts
+++ b/server/src/modules/TDDCycles/Application/postTDDLogUseCase.ts
@@ -1,0 +1,19 @@
+import { IDBJobsRepository } from "../Domain/IDBJobsRepository";
+import { ITimelineEntry } from "../Domain/ITimelineCommit";
+
+export class PostTDDLogUseCase {
+  private readonly dbJobRepository: IDBJobsRepository;
+
+  constructor(dbJobRepository: IDBJobsRepository) {
+    this.dbJobRepository = dbJobRepository;
+  }
+  
+  async execute(timeline: ITimelineEntry[]) {
+    try {
+      await this.dbJobRepository.saveLogs(timeline);
+    } catch (error) {
+      console.error("Error al guardar los registros de timeline en la base de datos:", error);
+      throw error;
+    }
+  }
+}

--- a/server/src/modules/TDDCycles/Domain/IDBJobsRepository.ts
+++ b/server/src/modules/TDDCycles/Domain/IDBJobsRepository.ts
@@ -1,6 +1,7 @@
 import { Pool } from 'pg';
 import { TestResultDataObject } from './TestResultDataObject';
 import { JobDataObject } from './JobDataObject';
+import { ITimelineEntry } from './ITimelineCommit';
 
 export interface IDBJobsRepository {
     pool: Pool;
@@ -10,4 +11,5 @@ export interface IDBJobsRepository {
     repositoryExists(owner: string, repoName: string): Promise<boolean>;
     getJobsNotSaved(owner: string, repoName: string, commitsWithActions: [string, number][]): Promise<[string, number][]>;
     saveJobsList(owner: string, repoName: string, jobs: Record<string, JobDataObject>): Promise<void>;
+    saveLogs(timeline: ITimelineEntry[]): Promise<void>;
 }

--- a/server/src/modules/TDDCycles/Domain/ITimelineCommit.ts
+++ b/server/src/modules/TDDCycles/Domain/ITimelineCommit.ts
@@ -1,0 +1,8 @@
+export interface ITimelineEntry {
+    execution_id: null;
+    commit_sha: string;
+    execution_timestamp: Date;
+    number_of_tests: number;
+    passed_tests: number;
+    color: string;
+}

--- a/server/src/routes/TDDCyclesRoutes.ts
+++ b/server/src/routes/TDDCyclesRoutes.ts
@@ -31,4 +31,10 @@ TDDCyclesRouter.get(
   async (req, res) => await tddCyclesController.getTestResults(req, res)
 );
 
+// Ruta para subir el archivo TDD log
+TDDCyclesRouter.post(
+  "/upload-log",
+  async (req, res) => await tddCyclesController.uploadTDDLog(req, res)
+);
+
 export default TDDCyclesRouter;

--- a/tddlabBaseProject/package.json
+++ b/tddlabBaseProject/package.json
@@ -9,7 +9,7 @@
     "build": "parcel build index.html",
     "test": "jest --watch",
     "test-once": "jest --verbose --coverage",
-    "test-export-json": "jest --json --outputFile=./script/report.json", 
+    "test-export-json": "jest --json --outputFile=./script/report.json",
     "tdd-script": "node ./script/tddScript.js",
     "cypress": "cypress open",
     "cypress-run": "cypress run",


### PR DESCRIPTION
Ahora podran acceder a la ruta /api/TDDCycles/upload-log y hacer un post con el body del tdd log json para que se guarde en la BD

1. Se procesa todo en el backend, se extrae las ejecuciones por cada commit y se guardan en la db
2. Se tiene cuidado con los duplicados, si el estudiante envia multiples veces el tdd log json, no se guardaran registro duplicados, las ejecuciones por commit son unicas y no se pueden modificar despues en la BD