### PR TITLE
Control de atajo para que funcione en todo el workspace

### DIFF
--- a/VSCodeExtension/package.json
+++ b/VSCodeExtension/package.json
@@ -19,8 +19,7 @@
     "keybindings":[
       {
         "command": "TDD.runTest",
-        "key": "ctrl+t",
-        "when": "editorTextFocus"
+        "key": "ctrl+t"
       }
     ],
     "commands": [


### PR DESCRIPTION
se quito la instancia para que el atajo ctrl + t funcione con solo estar en el workspace.