### PR TITLE
Correccion de codeSmell: useStat call is not destructed into value

### DIFF
--- a/Web Ui/src/sections/Assignments/AssignmentDetail.tsx
+++ b/Web Ui/src/sections/Assignments/AssignmentDetail.tsx
@@ -75,7 +75,7 @@ const AssignmentDetail: React.FC<AssignmentDetailProps> = ({
   const [loadingSubmissions, setLoadingSubmissions] = useState(true);
   const [submissions, setSubmissions] = useState<SubmissionDataObject[]>([]);
   const [studentSubmission,setStudentSubmission] = useState<SubmissionDataObject>();
-  const [, setSubmissionsError] = useState<string | null>(null);
+  const [_submissionsError, setSubmissionsError] = useState<string | null>(null);
   const [studentRows, setStudentRows] = useState<JSX.Element[]>([]);
   const [submission, setSubmission] = useState<SubmissionDataObject | null>(null);
   const navigate = useNavigate();
@@ -297,7 +297,7 @@ const AssignmentDetail: React.FC<AssignmentDetailProps> = ({
 
   const [isCommentDialogOpen, setIsCommentDialogOpen] = useState(false);
 
-  const [_, setComment] = useState("");
+  const [_comment, setComment] = useState("");
 
   const handleOpenCommentDialog = () => {
     setIsCommentDialogOpen(true);

--- a/Web Ui/src/sections/GroupInvitation/InvitationPage.tsx
+++ b/Web Ui/src/sections/GroupInvitation/InvitationPage.tsx
@@ -34,7 +34,7 @@ function InvitationPage() {
   const [user, setUser] = useState<User | null>(null);
   const [showPasswordPopup, setShowPasswordPopup] = useState(false);
   const [openPopup, setOpenPopup] = useState(false); 
-  const [, setPopupMessage] = useState(""); 
+  const [_popupMessage, setPopupMessage] = useState(""); 
 
   const dbAuthPort = new RegisterUserOnDb();
 


### PR DESCRIPTION
Origen: Web Ui/src/sections/Assignments/AssignmentDetail.tsx
Descripción: 
useState call is not destructured into value + setter pair
The return value of "useState" should be destructured and named symmetrically [typescript:S6754](
In React, useState is a hook that allows functional components to manage and update state in a manner similar to class components. When you use the useState hook, it returns an array with two values: the current state value and a function to update that state value.

Destructuring these values and naming them symmetrically (i.e., using consistent variable names for both the current state and the update function) is a recommended best practice:

When you destructure and name the values symmetrically, it makes your code more readable and self-explanatory. Other developers can quickly understand the purpose of each variable without needing to refer back to the useState function call.
Following a naming convention where the state variable and its corresponding update function have similar names is a common practice in the React community. It helps maintain consistency and makes it easier for others to understand your code.
If you don’t name the variables symmetrically, it can lead to confusion, especially in larger components or when multiple state variables are involved. You might accidentally use the wrong variable when updating the state, which can result in bugs that are hard to track down.