### PR TITLE
eliminando linea de foco

### DIFF
--- a/VSCodeExtension/src/extension.ts
+++ b/VSCodeExtension/src/extension.ts
@@ -34,7 +34,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Observa el archivo JSON para detectar cambios
     fs.watch(jsonFilePath, (eventType, filename) => {
         if (eventType === 'change') {
-            vscode.commands.executeCommand('workbench.view.extension.timelineContainer');
+            
 
             if (timelineView.currentWebview) {
               timelineView.showTimeline(timelineView.currentWebview);


### PR DESCRIPTION
se elimino una linea que enfoca el timeline cuando se ejecuta las pruebas para que El estudiante pueda ver la salida de jest para poder seguir con TDD