### PR TITLE
Correccion de error de mantenibilidad: add logic to this catch clause…

### DIFF
--- a/server/src/modules/TDDCycles/Application/getTDDCyclesUseCase.ts
+++ b/server/src/modules/TDDCycles/Application/getTDDCyclesUseCase.ts
@@ -64,6 +64,7 @@ export class GetTDDCyclesUseCase {
 
       return commits;
     } catch (error) {
+      console.error(`Error al ejecutar: ${error}`);
       throw error;
     }
   }

--- a/server/src/modules/TDDCycles/Application/getTestResultsUseCase.ts
+++ b/server/src/modules/TDDCycles/Application/getTestResultsUseCase.ts
@@ -33,6 +33,7 @@ export class GetTestResultsUseCase {
       const jobs = await this.dbJobRepository.getJobs(owner, repoName);
       return jobs;
     } catch (error) {
+      console.error("Error:", error);
       throw error;
     }
   }


### PR DESCRIPTION
… or eliminate it - getTDDCyclesUseCase.ts - getTestResultsUseCase.ts

Ubicación:
server/src/modules/TDDCycles/Application/getTDDCyclesUseCase.ts
server/src/modules/TDDCycles/Application/getTestResultsUseCase.ts
WHY:
A catch clause that only rethrows the caught exception has the same effect as omitting the catch altogether and letting it bubble up automatically.

try {
  doSomething();
} catch (ex) {  // Noncompliant
  throw ex;
}
Such clauses should either be removed or populated with the appropriate logic.

doSomething();
or

try {
  doSomething();
} catch (ex) {
  console.err(ex);
  throw ex;
}