### PR TITLE
use RegExp.exec() method instead

### DIFF
--- a/Web Ui/src/modules/Assignments/application/HandleUploadTDDLogFile.ts
+++ b/Web Ui/src/modules/Assignments/application/HandleUploadTDDLogFile.ts
@@ -70,7 +70,10 @@ const parseJSON = (fileContent: string): any => {
 
 const enrichWithRepoData = (jsonData: any, repoLink?: string) => {
   if (!repoLink) throw new Error("Enlace del repositorio no proporcionado.");
-  const repoMatch = repoLink.match(/https:\/\/github\.com\/([^/]+)\/([^/]+)/);
+  
+  const regex = /https:\/\/github\.com\/([^/]+)\/([^/]+)/;
+  const repoMatch = regex.exec(repoLink); // Cambio realizado: usamos regex.exec().
+
   if (!repoMatch) throw new Error("Enlace del repositorio inválido.");
   return { repoName: repoMatch[2], repoOwner: repoMatch[1], log: jsonData };
 };


### PR DESCRIPTION
Use the "RegExp.exec()" method instead.
TYPE:
maintainability
WHY:
String.match() behaves the same way as RegExp.exec() when the regular expression does not include the global flag g. While they work the same, RegExp.exec() can be slightly faster than String.match(). Therefore, it should be preferred for better performance.

The rule reports an issue on a call to String.match() whenever it can be replaced with semantically equivalent RegExp.exec().

'foo'.match(/bar/);
Rewrite the pattern matching from string.match(regex) to regex.exec(string).

/bar/.exec('foo');
