### PR TITLE
se corrigió el insert del color de una ejecucion

### DIFF
--- a/server/src/controllers/TDDCycles/TDDCyclesController.ts
+++ b/server/src/controllers/TDDCycles/TDDCyclesController.ts
@@ -121,7 +121,7 @@ class TDDCyclesController {
           {
             const testEntry = tddLog[j];
             if(testEntry.numPassedTests !== undefined && testEntry.numTotalTests !== undefined && testEntry.timestamp){
-              const color = testEntry.numPassedTests === testEntry.numTotalTests ? "green" : "red";
+              const color = testEntry.numTotalTests === 0 ? "red" : (testEntry.numPassedTests === testEntry.numTotalTests ? "green" : "red");
               const commitTimelineEntry: ITimelineEntry = {
                 execution_id: null, 
                 commit_sha: actualCommitSha,

--- a/server/src/controllers/TDDCycles/TDDCyclesController.ts
+++ b/server/src/controllers/TDDCycles/TDDCyclesController.ts
@@ -101,6 +101,17 @@ class TDDCyclesController {
   async uploadTDDLog(req: Request, res: Response) {
     
     try {
+
+      const getColor = (testEntry: any): string => {
+        if (testEntry.numTotalTests === 0) {
+          return "red";
+        } else if (testEntry.numPassedTests === testEntry.numTotalTests) {
+          return "green";
+        } else {
+          return "red";
+        }
+      };
+
       const { repoOwner, repoName, log: tddLog } = req.body;
       if (!repoOwner || !repoName || !tddLog) {
         return res.status(400).json({ error: "Faltan campos requeridos: repoOwner, repoName o log." });
@@ -121,7 +132,7 @@ class TDDCyclesController {
           {
             const testEntry = tddLog[j];
             if(testEntry.numPassedTests !== undefined && testEntry.numTotalTests !== undefined && testEntry.timestamp){
-              const color = testEntry.numTotalTests === 0 ? "red" : (testEntry.numPassedTests === testEntry.numTotalTests ? "green" : "red");
+              const color = getColor(testEntry);
               const commitTimelineEntry: ITimelineEntry = {
                 execution_id: null, 
                 commit_sha: actualCommitSha,


### PR DESCRIPTION
Antes las ejecuciones con 0 tests creados se pintaban de verde en el timeline del web, pero ahora en concordancia con lo que hizo el equipo over flores, se pintan de color rojo