### PR TITLE
Cod smells: imported multiple times

### DIFF
--- a/Web Ui/src/modules/Assignments/application/UploadTDDLogFile.ts
+++ b/Web Ui/src/modules/Assignments/application/UploadTDDLogFile.ts
@@ -1,7 +1,7 @@
 import JSZip from "jszip";
 import CryptoJS from "crypto-js";
-import { VITE_API } from "../../../../config";
-import { VITE_DECRYPTION_KEY } from "../../../../config";
+import { VITE_API, VITE_DECRYPTION_KEY } from "../../../../config";
+
 
 
 export const UploadTDDLogFile = async (

--- a/Web Ui/src/sections/Assignments/components/AssignmentsList.tsx
+++ b/Web Ui/src/sections/Assignments/components/AssignmentsList.tsx
@@ -1,17 +1,14 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { CircularProgress } from "@mui/material";
-import AssignmentsRepository from "../../../modules/Assignments/repository/AssignmentsRepository";
-import {
-  Table,
+import { CircularProgress, Table,
   TableHead,
   TableBody,
   TableRow,
   TableCell,
   Container,
   Button,
-  SelectChangeEvent,
-} from "@mui/material";
+  SelectChangeEvent } from "@mui/material";
+import AssignmentsRepository from "../../../modules/Assignments/repository/AssignmentsRepository";
 
 import { styled } from "@mui/system";
 import { AssignmentDataObject } from "../../../modules/Assignments/domain/assignmentInterfaces";


### PR DESCRIPTION
Web Ui/src/modules/Assignments/application/UploadTDDLogFile.ts
Web Ui/src/sections/Assignments/components/AssignmentsList.tsx
WHY:
Having the same module imported multiple times can affect code readability and maintainability. It makes hard to identify which modules are being used.

import { B1 } from 'b';
import { B2 } from 'b'; // Noncompliant: there is already an import from module 'b'.
Instead, one should consolidate the imports from the same module into a single statement. By consolidating all imports from the same module in a single import statement, the code becomes more concise and easier to read, as there is only one import statement to keep track of. Additionally, it can make it easier to identify which modules are used in the code.

import { B1, B2 } from 'b';