### PR TITLE
Correccion bóton INICIAR TAREA que generaba duplicación de tareas

### DIFF
--- a/Web Ui/src/sections/Assignments/AssignmentDetail.tsx
+++ b/Web Ui/src/sections/Assignments/AssignmentDetail.tsx
@@ -225,7 +225,6 @@ const AssignmentDetail: React.FC<AssignmentDetailProps> = ({
             const getSubmissionsByAssignmentId = new GetSubmissionsByAssignmentId(submissionRepository);
             const allSubmissions = await getSubmissionsByAssignmentId.getSubmissionsByAssignmentId(assignmentid);
             const userSubmission = allSubmissions.find(submission => submission.userid === userid);
-            // Ya no necesitas setSubmissionStatus aquí
             if (userSubmission) {
               setStudentSubmission(userSubmission);
             }


### PR DESCRIPTION
Se eliminó el estado y la lógica de submissionStatus porque generaba redundancia y, al hacer doble llamada al estado de la entrega de una tarea, podía provocar que el botón "Iniciar tarea" se habilitara incorrectamente aunque el estudiante ya tuviera una entrega. Ahora, el botón se deshabilita correctamente usando solo studentSubmission, se evita inconsistencia y se realiza una sola llamada al estado de la tarea.