### PR TITLE
Refactor GroupInvitation styles

### DIFF
--- a/Web Ui/src/sections/GroupInvitation/InvitationPage.tsx
+++ b/Web Ui/src/sections/GroupInvitation/InvitationPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { CSSProperties, useEffect, useState } from "react";
 import { getAuth, onAuthStateChanged, User } from "firebase/auth";
 import firebase from "../../firebaseConfig";
 import SuccessfulEnrollmentPopUp from "./components/SuccessfulEnrollmentPopUp";
@@ -19,6 +19,7 @@ import { useLocation } from "react-router-dom";
 import PasswordComponent from "./components/PasswordPopUp";
 import CheckRegisterGroupPopUp from "./components/CheckRegisterGroupPopUp";
 import AdminAlertModal from "./components/AdminAlertModal";
+import "./styles/GroupInvitation.css";
 
 function InvitationPage() {
   const location = useLocation();
@@ -111,21 +112,7 @@ function InvitationPage() {
   };
 
   const LoadingOverlay = () => (
-    <div
-      style={{
-        position: "fixed",
-        top: 0,
-        left: 0,
-        width: "100%",
-        height: "100%",
-        backgroundColor: "rgba(255, 255, 255, 0.8)",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        zIndex: 99999,
-        backdropFilter: "blur(5px)", //blur
-      }}
-    >
+    <div className="gi-loading-overlay">
       <CircularProgress size={60} />
     </div>
   );
@@ -184,8 +171,13 @@ function InvitationPage() {
   const handleMouseLeave = () => {
     setRotation({ rotateX: 0, rotateY: 0 });
   };
+  const inviteMediaStyle: CSSProperties = {
+    "--gi-rotate-x": `${rotation.rotateX}deg`,
+    "--gi-rotate-y": `${rotation.rotateY}deg`,
+  } as CSSProperties;
+
   return (
-    <div style={{ position: "relative" }}>
+    <div className="gi-root">
       {isLoading && <LoadingOverlay />}
 
       {user ? (
@@ -195,43 +187,26 @@ function InvitationPage() {
             spacing={2} // Agrega la separación deseada entre los Card
             justifyContent="center" // Centra los elementos horizontalmente
             alignItems="center" // Centra los elementos verticalmente
-            style={{ minHeight: "100vh" }} // Asegura que los elementos ocupen toda la altura de la vista
+            className="gi-full-height"
             direction="column" // Alinea los elementos en una sola columna
           >
             <Grid
               item
-              style={{
-                width: user.displayName ? "400px" : "600px",
-                transition: "width 0.3s ease",
-              }}
+              className={`gi-profile-card-item ${
+                user.displayName
+                  ? "gi-profile-card-item--compact"
+                  : "gi-profile-card-item--wide"
+              }`}
             >
               <Card
-                sx={{
-                  "&:hover": {
-                    boxShadow: "md",
-                    borderColor: "neutral.outlinedHoverBorder",
-                  },
-                }}
+                className="gi-card-hover"
                 variant="outlined"
               >
                 <CardContent>
                   <Grid container spacing={2}>
                     <Grid item xs={4}>
-                      <div
-                        style={{
-                          width: "100%",
-                          display: "flex",
-                          justifyContent: "center",
-                        }}
-                      >
-                        <div
-                          style={{
-                            width: 100,
-                            height: 100,
-                            borderRadius: "10%",
-                            overflow: "hidden",
-                          }}
-                        >
+                      <div className="gi-avatar-wrapper">
+                        <div className="gi-avatar">
                           <CardMedia
                             component="img"
                             alt="Imagen"
@@ -250,11 +225,11 @@ function InvitationPage() {
                       justifyContent="space-between"
                     >
                       <Grid item>
-                        <Typography variant="h5" sx={{ marginBottom: 1 }}>
+                        <Typography variant="h5" className="gi-user-name">
                           {user.displayName ?? user.email}
                         </Typography>
                       </Grid>
-                      <Grid item sx={{ marginTop: "auto" }}>
+                      <Grid item className="gi-signout-wrapper">
                         <Button
                           onClick={handleGithubSignOut}
                           variant="contained"
@@ -271,10 +246,11 @@ function InvitationPage() {
             </Grid>
             <Grid item>
               <Card
-                sx={{
-                  width: user.displayName ? "400px" : "500px",
-                  transition: "width 0.5s ease",
-                }}
+                className={`gi-invite-card-item ${
+                  user.displayName
+                    ? "gi-invite-card-item--compact"
+                    : "gi-invite-card-item--wide"
+                }`}
                 variant="outlined"
               >
                 <CardMedia
@@ -282,17 +258,13 @@ function InvitationPage() {
                   alt="Imagen de portada"
                   height="50%" // La mitad superior del card
                   image="https://images.pexels.com/photos/6804068/pexels-photo-6804068.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1" // Reemplaza con la ruta de tu imagen
-                  sx={{
-                    transition: "transform 0.1s ease-out",
-                    transformStyle: "preserve-3d",
-                    transform: `rotateX(${rotation.rotateX}deg) rotateY(${rotation.rotateY}deg)`,
-                    boxShadow: "10px 10px 20px rgba(0, 0, 0, 0.5)",
-                  }}
+                  className="gi-invite-media"
+                  style={inviteMediaStyle}
                   onMouseMove={handleMouseMove}
                   onMouseLeave={handleMouseLeave}
                 />
                 <CardContent>
-                  <Typography variant="body1" sx={{ textAlign: "center" }}>
+                  <Typography variant="body1" className="gi-invite-text">
                     Israel Antezana te está invitando al curso
                   </Typography>
                   {userType === "student" && (
@@ -300,7 +272,7 @@ function InvitationPage() {
                       onClick={() => handleAcceptInvitation("student")}
                       variant="contained"
                       color="primary"
-                      sx={{ marginTop: 2 }}
+                      className="gi-invite-button"
                       fullWidth
                       disabled={isLoading}
                     >
@@ -312,7 +284,7 @@ function InvitationPage() {
                       onClick={handlePopPassword}
                       variant="contained"
                       color="primary"
-                      sx={{ marginTop: 2 }}
+                      className="gi-invite-button"
                       fullWidth
                       disabled={isLoading}
                     >
@@ -340,36 +312,20 @@ function InvitationPage() {
           direction="column"
           alignItems="center"
           justifyContent="center"
-          style={{ minHeight: "100vh" }}
+          className="gi-full-height"
         >
           <Grid item>
-            <div style={{ display: "flex", gap: "15px", flexWrap: "wrap", justifyContent: "center" }}>
+            <div className="gi-auth-buttons">
               <Button 
                 onClick={handleSignUp} 
                 disabled={isLoading}
                 variant="contained"
-                sx={{ 
-                  backgroundColor: "#24292e",
-                  color: "white",
-                  padding: "10px 20px",
-                  textTransform: "uppercase",
-                  fontWeight: 500,
-                  "&:hover": { 
-                    backgroundColor: "#1a1e22"
-                  },
-                  "&:disabled": {
-                    backgroundColor: "#ccc"
-                  }
-                }}
+                className="gi-auth-button gi-auth-button--github"
               >
                 <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
+                  className="gi-auth-button-content"
                 >
-                  <GitHubIcon style={{ marginRight: "8px" }} />
+                  <GitHubIcon className="gi-auth-icon" />
                   Registrarse con GitHub
                 </div>
               </Button>
@@ -377,28 +333,12 @@ function InvitationPage() {
                 onClick={handleSignUpWithGoogle} 
                 disabled={isLoading}
                 variant="contained"
-                sx={{ 
-                  backgroundColor: "#4285f4",
-                  color: "white",
-                  padding: "10px 20px",
-                  textTransform: "uppercase",
-                  fontWeight: 500,
-                  "&:hover": { 
-                    backgroundColor: "#3367d6"
-                  },
-                  "&:disabled": {
-                    backgroundColor: "#ccc"
-                  }
-                }}
+                className="gi-auth-button gi-auth-button--google"
               >
                 <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
+                  className="gi-auth-button-content"
                 >
-                  <GoogleIcon style={{ marginRight: "8px" }} />
+                  <GoogleIcon className="gi-auth-icon" />
                   Registrarse con Google
                 </div>
               </Button>

--- a/Web Ui/src/sections/GroupInvitation/components/AdminAlertModal.tsx
+++ b/Web Ui/src/sections/GroupInvitation/components/AdminAlertModal.tsx
@@ -1,6 +1,7 @@
 import { Dialog, Typography, Button, Box, Zoom } from "@mui/material";
 import WarningAmberRoundedIcon from "@mui/icons-material/WarningAmberRounded";
 import { useNavigate } from "react-router-dom";
+import "../styles/GroupInvitation.css";
 
 interface AdminAlertModalProps {
   open: boolean;
@@ -18,74 +19,37 @@ export default function AdminAlertModal({ open }: AdminAlertModalProps) {
       open={open}
       TransitionComponent={Zoom}
       PaperProps={{
-        sx: {
-          backgroundColor: "#fdfdfd",
-          color: "#2b2b2b",
-          borderRadius: "16px",
-          p: 4,
-          fontFamily: "Inter, Roboto, sans-serif",
-          boxShadow: "0 8px 24px rgba(0, 0, 0, 0.25)",
-          textAlign: "center",
-          width: "380px",
-          mx: "auto",
-        },
+        className: "gi-admin-modal-paper",
       }}
       BackdropProps={{
-        sx: {
-          backdropFilter: "blur(6px)",
-          backgroundColor: "rgba(0,0,0,0.25)",
-        },
+        className: "gi-admin-modal-backdrop",
       }}
     >
       <Box
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-        justifyContent="center"
-        gap={2}
+        className="gi-admin-modal-content"
       >
-        <WarningAmberRoundedIcon sx={{ fontSize: 70, color: "#1976D2" }} />
+        <WarningAmberRoundedIcon className="gi-admin-modal-icon" />
 
         <Typography
           variant="h5"
-          sx={{
-            fontWeight: 600,
-            mb: 1,
-            letterSpacing: "0.3px",
-          }}
+          className="gi-admin-modal-title"
         >
           Acceso restringido
         </Typography>
 
         <Typography
           variant="body1"
-          sx={{
-            maxWidth: 300,
-            fontSize: "0.95rem",
-            color: "#4b4b4b",
-            lineHeight: 1.6,
-          }}
+          className="gi-admin-modal-body"
         >
           Este enlace pertenece a un usuario de tipo{" "}
-          <strong style={{ color: "#1976D2" }}>admin</strong>. <br />
+          <strong className="gi-admin-modal-highlight">admin</strong>. <br />
           Serás redirigido al inicio de sesión.
         </Typography>
 
         <Button
           onClick={handleClose}
           variant="contained"
-          sx={{
-            mt: 3,
-            px: 4,
-            py: 1.2,
-            fontWeight: "bold",
-            borderRadius: "12px",
-            textTransform: "none",
-            backgroundColor: "#1976D2",
-            "&:hover": {
-              backgroundColor: "#1565C0",
-            },
-          }}
+          className="gi-admin-modal-button"
         >
           Ir al login
         </Button>

--- a/Web Ui/src/sections/GroupInvitation/styles/GroupInvitation.css
+++ b/Web Ui/src/sections/GroupInvitation/styles/GroupInvitation.css
@@ -1,0 +1,191 @@
+.gi-root {
+  position: relative;
+}
+
+.gi-loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 99999;
+  backdrop-filter: blur(5px);
+}
+
+.gi-full-height {
+  min-height: 100vh;
+}
+
+.gi-profile-card-item {
+  transition: width 0.3s ease;
+}
+
+.gi-profile-card-item--compact {
+  width: 400px;
+}
+
+.gi-profile-card-item--wide {
+  width: 600px;
+}
+
+.gi-card-hover:hover {
+  box-shadow: var(--mui-shadows-4, 0 4px 12px rgba(0, 0, 0, 0.12));
+  border-color: var(--mui-palette-neutral-outlinedHoverBorder, rgba(0, 0, 0, 0.23));
+}
+
+.gi-avatar-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.gi-avatar {
+  width: 100px;
+  height: 100px;
+  border-radius: 10%;
+  overflow: hidden;
+}
+
+.gi-user-name {
+  margin-bottom: 8px;
+}
+
+.gi-signout-wrapper {
+  margin-top: auto;
+}
+
+.gi-invite-card-item {
+  transition: width 0.5s ease;
+}
+
+.gi-invite-card-item--compact {
+  width: 400px;
+}
+
+.gi-invite-card-item--wide {
+  width: 500px;
+}
+
+.gi-invite-media {
+  transition: transform 0.1s ease-out;
+  transform-style: preserve-3d;
+  transform: rotateX(var(--gi-rotate-x, 0deg)) rotateY(var(--gi-rotate-y, 0deg));
+  box-shadow: 10px 10px 20px rgba(0, 0, 0, 0.5);
+}
+
+.gi-invite-text {
+  text-align: center;
+}
+
+.gi-invite-button {
+  margin-top: 16px;
+}
+
+.gi-auth-buttons {
+  display: flex;
+  gap: 15px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.gi-auth-button.MuiButton-root {
+  color: #ffffff;
+  padding: 10px 20px;
+  text-transform: uppercase;
+  font-weight: 500;
+}
+
+.gi-auth-button--github.MuiButton-root {
+  background-color: #24292e;
+}
+
+.gi-auth-button--github.MuiButton-root:hover {
+  background-color: #1a1e22;
+}
+
+.gi-auth-button--google.MuiButton-root {
+  background-color: #4285f4;
+}
+
+.gi-auth-button--google.MuiButton-root:hover {
+  background-color: #3367d6;
+}
+
+.gi-auth-button.Mui-disabled {
+  background-color: #cccccc !important;
+  color: #ffffff;
+}
+
+.gi-auth-button-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.gi-auth-icon {
+  margin-right: 8px;
+}
+
+.gi-admin-modal-paper {
+  background-color: #fdfdfd;
+  color: #2b2b2b;
+  border-radius: 16px;
+  padding: 32px;
+  font-family: Inter, Roboto, sans-serif;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  text-align: center;
+  width: 380px;
+  margin: 0 auto;
+}
+
+.gi-admin-modal-backdrop {
+  backdrop-filter: blur(6px);
+  background-color: rgba(0, 0, 0, 0.25);
+}
+
+.gi-admin-modal-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+}
+
+.gi-admin-modal-icon {
+  font-size: 70px;
+  color: #1976d2;
+}
+
+.gi-admin-modal-title {
+  font-weight: 600;
+  margin-bottom: 8px;
+  letter-spacing: 0.3px;
+}
+
+.gi-admin-modal-body {
+  max-width: 300px;
+  font-size: 0.95rem;
+  color: #4b4b4b;
+  line-height: 1.6;
+}
+
+.gi-admin-modal-highlight {
+  color: #1976d2;
+}
+
+.gi-admin-modal-button.MuiButton-root {
+  margin-top: 24px;
+  padding: 10px 32px;
+  font-weight: bold;
+  border-radius: 12px;
+  text-transform: none;
+  background-color: #1976d2;
+}
+
+.gi-admin-modal-button.MuiButton-root:hover {
+  background-color: #1565c0;
+}


### PR DESCRIPTION
## Que hice
- Moví estilos inline y `sx` a clases CSS del módulo GroupInvitation.
- Cree `GroupInvitation.css` y lo importé en `InvitationPage` y `AdminAlertModal`.
- Reemplacé estilos repetidos por clases reutilizables.

## Por que
- Mejor legibilidad y mantenimiento.
- Menos duplicacion de estilos.

## Pruebas
- npm test -- InvitationPage.test.tsx
