### PR TITLE
fix: lógica de estado activo en el menú para rutas de detalle y gráficas

### DIFF
--- a/Web Ui/src/App.tsx
+++ b/Web Ui/src/App.tsx
@@ -27,8 +27,27 @@ import { CircularProgress } from "@mui/material";
 
 const navArrayLinks = [
   { title: "Grupos", path: "/groups", icon: <GroupsIcon />, access: ["admin", "teacher"] },
-  { title: "Tareas", path: "/", icon: <DescriptionIcon />, access: ["admin", "student", "teacher"] },
-  { title: "Mis prácticas", path: "/mis-practicas", icon: <NoteAdd />, access: ["admin", "teacher", "student"] },
+  { 
+    title: "Tareas", 
+    path: "/assignments", 
+    icon: <DescriptionIcon />, 
+    access: ["admin", "student", "teacher"],
+    // Reglas adicionales para marcar como activo:
+    activeRules: {
+      paths: ["/assignments", "/assignment"], // Cubre lista y detalle
+      source: "assignment" // Si estamos en /graph?source=assignment
+    }
+  },
+  { 
+    title: "Mis prácticas", 
+    path: "/mis-practicas", 
+    icon: <NoteAdd />, 
+    access: ["admin", "teacher", "student"],
+    activeRules: {
+      paths: ["/mis-practicas"], 
+      source: "practice" // Si estamos en /graph?source=practice
+    }
+  },
   { title: "Usuarios", path: "/user", icon: <PersonIcon />, access: ["admin", "teacher"] },
   { title: "Ajustes", path: "/configuraciones", icon: <SettingsIcon />, access: ["admin", "teacher"] },
 ];
@@ -60,11 +79,6 @@ function App() {
   }, []);
 
   if (authData.userid === undefined) {
-    /*
-      CAMBIO 1: div con style={{ display:"flex", justifyContent:"center",
-      alignItems:"center", height:"100vh", width:"100vw" }}
-      → className="fullscreen-loading" (definida en App.css)
-    */
     return (
       <div className="fullscreen-loading">
         <CircularProgress />
@@ -79,7 +93,7 @@ function App() {
       )}
       <Routes>
         <Route
-          path="/"
+          path="/assignments"
           element={
             <ProtectedRouteComponent>
               <GestionTareas userRole={authData.userRole ?? ""} userGroupid={authData.usergroupid ?? -1} />

--- a/Web Ui/src/sections/Assignments/AssignmentDetail.tsx
+++ b/Web Ui/src/sections/Assignments/AssignmentDetail.tsx
@@ -221,6 +221,7 @@ const AssignmentDetail: React.FC<AssignmentDetailProps> = ({ role, userid }) => 
             repoName: repo,
             fetchedSubmissions: JSON.stringify(fetchedSubmissions),
             submissionId: submissionId.toString(),
+            source: "assignment"
           }).toString(),
         });
       } else {
@@ -319,8 +320,12 @@ const AssignmentDetail: React.FC<AssignmentDetailProps> = ({ role, userid }) => 
                 className="btn-std btn-primary"
                 disabled={!sub.repository_link}
                 onClick={() =>
-                  navigate("/asistente-ia", {
-                    state: { repositoryLink: sub.repository_link },
+                  navigate({
+                    pathname: "/asistente-ia",
+                    search: createSearchParams({
+                      repositoryLink: sub.repository_link,
+                      source: "assignment" 
+                    }).toString(),
                   })
                 }
               >
@@ -426,7 +431,8 @@ const AssignmentDetail: React.FC<AssignmentDetailProps> = ({ role, userid }) => 
                     handleRedirectStudent(
                       submission.repository_link,
                       submission.id,
-                      navigate
+                      navigate,
+                      "assignment"
                     )
                   }
                   className="btn-std btn-primary"

--- a/Web Ui/src/sections/MainMenu/MainMenu.tsx
+++ b/Web Ui/src/sections/MainMenu/MainMenu.tsx
@@ -33,8 +33,27 @@ export default function MainMenu({
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const authData = useGlobalState("authData"); 
-  
-  const isActive = (path: string) => location.pathname === path;
+
+  const isActive = (item: any) => {
+    const { pathname, search } = location;
+    const params = new URLSearchParams(search);
+    const source = params.get("source");
+
+    if (pathname === "/graph" || pathname === "/asistente-ia") {
+      if (item.path === "/assignments") return source === "assignment";
+      if (item.path === "/mis-practicas") return source === "practice";
+    }
+
+    if (item.path === "/assignments") {
+      return pathname.startsWith("/assignments") || pathname.startsWith("/assignment");
+    }
+
+    if (item.path === "/mis-practicas") {
+      return pathname.startsWith("/mis-practicas");
+    }
+
+    return pathname.startsWith(item.path);
+  };
 
   const handleLogoutAction = async () => {
     await handleGithubSignOut();
@@ -76,7 +95,7 @@ export default function MainMenu({
                     key={item.title}
                     component={NavLink}
                     to={item.path}
-                    className={`nav-link-btn ${isActive(item.path) ? "nav-link-active" : ""}`}
+                    className={`nav-link-btn ${isActive(item) ? "nav-link-active" : ""}`}
                   >
                     {item.title}
                   </Button>

--- a/Web Ui/src/sections/MainMenu/styles/MainMenuStyles.css
+++ b/Web Ui/src/sections/MainMenu/styles/MainMenuStyles.css
@@ -54,15 +54,16 @@
 .nav-link-active { 
   opacity: 1 !important;
   font-weight: 700 !important; 
+  font-size: 1.2rem !important; 
 }
 
 .nav-link-active::after {
   content: "";
   position: absolute;
-  bottom: 12px; 
-  left: 20px;   
-  right: 20px;  
-  height: 3px;
+  bottom: 15px; 
+  left: 15px;   
+  right: 15px;  
+  height: 4px;
   background-color: #ffffff;
   border-radius: 2px; 
 }

--- a/Web Ui/src/sections/MyPractices/PracticeDetail.tsx
+++ b/Web Ui/src/sections/MyPractices/PracticeDetail.tsx
@@ -282,7 +282,8 @@ const PracticeDetail: React.FC<PracticeDetailProps> = ({ userid }) => {
                     handleRedirectStudent(
                       practiceSubmissions[0].repository_link,
                       practiceSubmissions[0].id,
-                      navigate
+                      navigate,
+                      "practice"
                     );
                   }
                 }}

--- a/Web Ui/src/sections/Shared/handlers.ts
+++ b/Web Ui/src/sections/Shared/handlers.ts
@@ -21,7 +21,8 @@ export const createLinkDialogHandlers = (
 export const handleRedirectStudent = (
   link: string,
   id : number,
-  navigate: NavigateFunction
+  navigate: NavigateFunction,
+  source: "assignment" | "practice" 
 ) => {
   if (link) {
     const regex = /https:\/\/github\.com\/([^/]+)\/([^/]+)/;
@@ -35,6 +36,7 @@ export const handleRedirectStudent = (
           repoOwner: user,
           repoName: repo,
           submissionId: id.toString(),
+          source: source 
         }).toString(),
       });
     } else {


### PR DESCRIPTION
## Problema
El menú principal (MainMenu) no marcaba correctamente como "activa" la sección correspondiente en los siguientes casos:

1. Al entrar al detalle de una tarea (/assignment/:id), debido a la discrepancia entre el path del menú (/assignments) y la ruta singular.
2. Al navegar a la visualización de gráficas (/graph), ya que esta ruta es compartida tanto por Tareas como por Prácticas, y el menú no tenía forma de distinguir el contexto.

## Solución
Se ha implementado un sistema de detección de contexto basado en parámetros de búsqueda (URLSearchParams) y una lógica de coincidencia de rutas más flexible:

1. Contexto por source: Se modificaron los handlers de redirección (handleRedirectStudent y handleRedirectAdmin) para incluir el parámetro ?source=assignment o ?source=practice en la URL.
2. Lógica isActive mejorada:

   -  Ahora el MainMenu detecta el parámetro source para decidir qué ítem activar cuando el usuario está en /graph o /asistente-ia.
   - Se añadió soporte para prefijos en singular (ej: /assignment ahora activa el botón de /assignments).

5. Refactor de Handlers: Se actualizó el helper compartido para permitir la inyección dinámica del origen de la navegación.

<img width="1900" height="282" alt="Captura de pantalla 2026-05-02 125041" src="https://github.com/user-attachments/assets/9a908e9a-96ac-4270-9b0f-7afe4f5c35a7" />
