### PR TITLE
Ajustes vibing coders

### DIFF
--- a/Web Ui/src/App.css
+++ b/Web Ui/src/App.css
@@ -458,7 +458,7 @@ body * { font-family: var(--font-family) !important; }
 
 /* Estilo para el input de Prompt cuando está bloqueado */
 .prompt-input-readonly {
-  background-color: #f5f5f5 !important;
+  background-color: #ffffff !important;
   cursor: default;
 }
 /* ==========================================================================

--- a/Web Ui/src/App.css
+++ b/Web Ui/src/App.css
@@ -358,12 +358,15 @@ body * { font-family: var(--font-family) !important; }
   font-weight: 600;
   font-size: 16px;
   margin-bottom: 8px;
+  color: #111111;
 }
 
 .settings-section-title--spaced {
-  font-weight: 600;
-  font-size: 16px;
-  margin: 1.5rem 0 0.5rem 0;
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 1.2;
+  margin: 2rem 0 1.25rem 0;
+  color: #111111;
 }
 
 /* Overlay de carga al guardar prompts */
@@ -381,11 +384,70 @@ body * { font-family: var(--font-family) !important; }
 }
 
 /* Items de checkboxes en settings */
+.settings-flag-list {
+  width: 100%;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
 .settings-flag-item {
-  margin-bottom: 10px;
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: space-between;
+  gap: 24px;
+  width: 100%;
+  font-size: 18px;
+  line-height: 1.35;
+  color: #111111;
+}
+
+.settings-flag-name {
+  flex: 1;
+  min-width: 0;
+}
+
+.settings-flag-checkbox {
+  width: 22px;
+  height: 22px;
+  margin: 0;
+  cursor: pointer;
+  flex: 0 0 auto;
+  transform: translateY(-1px);
+  appearance: none;
+  -webkit-appearance: none;
+  border: 2px solid #6bbf45;
+  border-radius: 4px;
+  background: #ffffff;
+  display: grid;
+  place-content: center;
+}
+
+.settings-flag-checkbox::after {
+  content: "";
+  width: 6px;
+  height: 11px;
+  border-right: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  transform: rotate(45deg) scale(0);
+  transition: transform 0.12s ease-in-out;
+  margin-top: -2px;
+}
+
+.settings-flag-checkbox:checked {
+  background: #6bbf45;
+}
+
+.settings-flag-checkbox:checked::after {
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  transform: rotate(45deg) scale(1);
+}
+
+.settings-flag-checkbox:focus-visible {
+  outline: 2px solid rgba(105, 191, 69, 0.45);
+  outline-offset: 2px;
 }
 
 .settings-error-text {

--- a/Web Ui/src/sections/Settings/SettingsPage.tsx
+++ b/Web Ui/src/sections/Settings/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { UpdatePrompts } from '../../modules/AIAssistant/application/UpdatePromp
 import { GetFeatureFlags } from "../../modules/FeatureFlags/application/GetFeatureFlags";
 import { FeatureFlag } from "../../modules/FeatureFlags/domain/FeatureFlag";
 import { UpdateFeatureFlag } from "../../modules/FeatureFlags/application/UpdateFeatureFlag";
+import { ConfirmationDialog } from "../Shared/Components/ConfirmationDialog";
 import "../../App.css";
 
 const PROMPT_OPTIONS = [
@@ -25,6 +26,8 @@ const ConfigurationPage = () => {
     message: string;
     severity: 'success' | 'error' | 'info' | 'warning';
   }>({ open: false, message: '', severity: 'info' });
+  const [flagConfirmationOpen, setFlagConfirmationOpen] = useState(false);
+  const [pendingFlag, setPendingFlag] = useState<FeatureFlag | null>(null);
   const [prompts, setPrompts] = useState<{ tddPrompt: string; refactoringPrompt: string; evaluateTDDPrompt: string }>({ tddPrompt: "", refactoringPrompt: "", evaluateTDDPrompt: "" });
   const [selectedPrompt, setSelectedPrompt] = useState<string>("tddPrompt");
   const [isEditing, setEditing] = useState(false);
@@ -99,18 +102,32 @@ const ConfigurationPage = () => {
 
   const handleCloseNotification = () => setNotification({ ...notification, open: false });
 
-  const handleCheckboxChange = async (id: number, currentValue: boolean) => {
-    const confirmChange = window.confirm(
-      `¿Estás seguro de que quieres ${!currentValue ? "habilitar" : "deshabilitar"} esta funcionalidad?`
-    );
-    if (!confirmChange) return;
+  const handleCheckboxChange = (flag: FeatureFlag) => {
+    setPendingFlag(flag);
+    setFlagConfirmationOpen(true);
+  };
+
+  const handleConfirmFlagChange = async () => {
+    if (!pendingFlag) return;
     try {
-      const updatedFlag = await updateFlagUseCase.execute(id, !currentValue);
-      setFlags((prevFlags) => prevFlags.map((flag) => flag.id === id ? updatedFlag : flag));
+      const updatedFlag = await updateFlagUseCase.execute(
+        pendingFlag.id,
+        !pendingFlag.is_enabled
+      );
+      setFlags((prevFlags) =>
+        prevFlags.map((flag) => (flag.id === pendingFlag.id ? updatedFlag : flag))
+      );
+      setFlagConfirmationOpen(false);
+      setPendingFlag(null);
     } catch (err) {
       console.error("Error al actualizar el flag", err);
       setError("Error al actualizar el flag");
     }
+  };
+
+  const handleCancelFlagChange = () => {
+    setFlagConfirmationOpen(false);
+    setPendingFlag(null);
   };
 
   return (
@@ -199,11 +216,36 @@ const ConfigurationPage = () => {
                 className="settings-flag-checkbox"
                 type="checkbox"
                 checked={flag.is_enabled}
-                onChange={() => handleCheckboxChange(flag.id, flag.is_enabled)}
+                onChange={() => handleCheckboxChange(flag)}
               />
             </label>
           ))}
         </div>
+
+        <ConfirmationDialog
+          open={flagConfirmationOpen}
+          title={
+            pendingFlag?.is_enabled
+              ? "Confirmar deshabilitación"
+              : "Confirmar habilitación"
+          }
+          content={
+            pendingFlag ? (
+              <>
+                {pendingFlag.is_enabled
+                  ? "Vas a deshabilitar"
+                  : "Vas a habilitar"}{" "}
+                la funcionalidad <strong>{pendingFlag.feature_name}</strong>.
+              </>
+            ) : (
+              ""
+            )
+          }
+          cancelText="Cancelar"
+          deleteText={pendingFlag?.is_enabled ? "Deshabilitar" : "Habilitar"}
+          onCancel={handleCancelFlagChange}
+          onDelete={handleConfirmFlagChange}
+        />
       </Container>
     </div>
   );

--- a/Web Ui/src/sections/Settings/SettingsPage.tsx
+++ b/Web Ui/src/sections/Settings/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { GetFeatureFlags } from "../../modules/FeatureFlags/application/GetFeatu
 import { FeatureFlag } from "../../modules/FeatureFlags/domain/FeatureFlag";
 import { UpdateFeatureFlag } from "../../modules/FeatureFlags/application/UpdateFeatureFlag";
 import { ConfirmationDialog } from "../Shared/Components/ConfirmationDialog";
+import { ValidationDialog } from "../Shared/Components/ValidationDialog";
 import "../../App.css";
 
 const PROMPT_OPTIONS = [
@@ -26,6 +27,8 @@ const ConfigurationPage = () => {
     message: string;
     severity: 'success' | 'error' | 'info' | 'warning';
   }>({ open: false, message: '', severity: 'info' });
+  const [flagValidationOpen, setFlagValidationOpen] = useState(false);
+  const [flagValidationMessage, setFlagValidationMessage] = useState("");
   const [flagConfirmationOpen, setFlagConfirmationOpen] = useState(false);
   const [pendingFlag, setPendingFlag] = useState<FeatureFlag | null>(null);
   const [prompts, setPrompts] = useState<{ tddPrompt: string; refactoringPrompt: string; evaluateTDDPrompt: string }>({ tddPrompt: "", refactoringPrompt: "", evaluateTDDPrompt: "" });
@@ -117,6 +120,8 @@ const ConfigurationPage = () => {
       setFlags((prevFlags) =>
         prevFlags.map((flag) => (flag.id === pendingFlag.id ? updatedFlag : flag))
       );
+      setFlagValidationMessage(pendingFlag.is_enabled ? "Se deshabilitó" : "Se habilitó");
+      setFlagValidationOpen(true);
       setFlagConfirmationOpen(false);
       setPendingFlag(null);
     } catch (err) {
@@ -128,6 +133,11 @@ const ConfigurationPage = () => {
   const handleCancelFlagChange = () => {
     setFlagConfirmationOpen(false);
     setPendingFlag(null);
+  };
+
+  const handleCloseFlagValidation = () => {
+    setFlagValidationOpen(false);
+    setFlagValidationMessage("");
   };
 
   return (
@@ -245,6 +255,14 @@ const ConfigurationPage = () => {
           deleteText={pendingFlag?.is_enabled ? "Deshabilitar" : "Habilitar"}
           onCancel={handleCancelFlagChange}
           onDelete={handleConfirmFlagChange}
+          confirmButtonClassName="btn-primary"
+        />
+
+        <ValidationDialog
+          open={flagValidationOpen}
+          title={flagValidationMessage}
+          closeText="Cerrar"
+          onClose={handleCloseFlagValidation}
         />
       </Container>
     </div>

--- a/Web Ui/src/sections/Settings/SettingsPage.tsx
+++ b/Web Ui/src/sections/Settings/SettingsPage.tsx
@@ -191,18 +191,19 @@ const ConfigurationPage = () => {
 
         {error && <p className="settings-error-text">{error}</p>}
 
-        {flags.map((flag) => (
-          <div key={flag.id} className="settings-flag-item">
-            <label>
+        <div className="settings-flag-list">
+          {flags.map((flag) => (
+            <label key={flag.id} className="settings-flag-item">
+              <span className="settings-flag-name">{flag.feature_name}</span>
               <input
+                className="settings-flag-checkbox"
                 type="checkbox"
                 checked={flag.is_enabled}
                 onChange={() => handleCheckboxChange(flag.id, flag.is_enabled)}
               />
-              {flag.feature_name}
             </label>
-          </div>
-        ))}
+          ))}
+        </div>
       </Container>
     </div>
   );

--- a/Web Ui/src/sections/Settings/SettingsPage.tsx
+++ b/Web Ui/src/sections/Settings/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { FormControl, InputLabel, Select, MenuItem,
-         Typography, Container, Box, CircularProgress, Snackbar, Alert } from '@mui/material';
+         Typography, Container, Box, CircularProgress } from '@mui/material';
 import EditPromptAI from './components/EditPromptAI';
 import { GetPrompts } from '../../modules/AIAssistant/application/GetPrompts';
 import { UpdatePrompts } from '../../modules/AIAssistant/application/UpdatePrompts';
@@ -22,11 +22,9 @@ const ConfigurationPage = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [saving, setSaving] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  const [notification, setNotification] = useState<{
-    open: boolean;
-    message: string;
-    severity: 'success' | 'error' | 'info' | 'warning';
-  }>({ open: false, message: '', severity: 'info' });
+  const [promptValidationOpen, setPromptValidationOpen] = useState(false);
+  const [promptValidationMessage, setPromptValidationMessage] = useState("");
+  const [promptValidationIsError, setPromptValidationIsError] = useState(false);
   const [flagValidationOpen, setFlagValidationOpen] = useState(false);
   const [flagValidationMessage, setFlagValidationMessage] = useState("");
   const [flagConfirmationOpen, setFlagConfirmationOpen] = useState(false);
@@ -89,10 +87,14 @@ const ConfigurationPage = () => {
         updatePrompts.evaluateTDDPrompt
       );
       setPrompts(updatePrompts);
-      setNotification({ open: true, message: "Prompt actualizado correctamente", severity: "success" });
+      setPromptValidationMessage("Prompt actualizado");
+      setPromptValidationIsError(false);
+      setPromptValidationOpen(true);
       setEditing(false);
     } catch (error) {
-      setNotification({ open: true, message: "Error al actualizar el prompt", severity: "error" });
+      setPromptValidationMessage("Error al actualizar el prompt");
+      setPromptValidationIsError(true);
+      setPromptValidationOpen(true);
     } finally {
       setSaving(false);
     }
@@ -103,7 +105,11 @@ const ConfigurationPage = () => {
     loadPrompts();
   };
 
-  const handleCloseNotification = () => setNotification({ ...notification, open: false });
+  const handleClosePromptValidation = () => {
+    setPromptValidationOpen(false);
+    setPromptValidationMessage("");
+    setPromptValidationIsError(false);
+  };
 
   const handleCheckboxChange = (flag: FeatureFlag) => {
     setPendingFlag(flag);
@@ -189,21 +195,6 @@ const ConfigurationPage = () => {
               onCancel={handleCancelEdit}
             />
 
-            <Snackbar
-              open={notification.open}
-              autoHideDuration={6000}
-              onClose={handleCloseNotification}
-              anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-            >
-              <Alert
-                onClose={handleCloseNotification}
-                severity={notification.severity}
-                sx={{ width: '100%' }}
-              >
-                {notification.message}
-              </Alert>
-            </Snackbar>
-
             {saving && (
               <div className="saving-overlay">
                 <CircularProgress color="primary" />
@@ -263,6 +254,14 @@ const ConfigurationPage = () => {
           title={flagValidationMessage}
           closeText="Cerrar"
           onClose={handleCloseFlagValidation}
+        />
+
+        <ValidationDialog
+          open={promptValidationOpen}
+          title={promptValidationMessage}
+          closeText="Cerrar"
+          onClose={handleClosePromptValidation}
+          isError={promptValidationIsError}
         />
       </Container>
     </div>

--- a/Web Ui/src/sections/Settings/SettingsPage.tsx
+++ b/Web Ui/src/sections/Settings/SettingsPage.tsx
@@ -14,7 +14,7 @@ import "../../App.css";
 const PROMPT_OPTIONS = [
   { label: "Prompt Analizar TDD", value: "tddPrompt" },
   { label: "Prompt Analizar Refactoring", value: "refactoringPrompt" },
-  { label: "Prompt Evaluar TDD", value: "evaluateTDDPrompt" },
+  { label: "Prompt Evaluar TDD", value: "evaluateTDDPrompt" }
 ];
 
 const ConfigurationPage = () => {
@@ -164,7 +164,7 @@ const ConfigurationPage = () => {
                 sx={{ mb: 2, width: '50%' }} 
                 size="small" // 'small' ayuda a que el label de MUI se alinee mejor con el alto de 36px
               >
-                <InputLabel id="prompt-select-label">Selecciona el tipo de Prompt</InputLabel>
+                <InputLabel id="prompt-select-label">Seleccionar tipo de Prompt</InputLabel>
                 <Select
                   labelId="prompt-select-label"
                   value={selectedPrompt}
@@ -213,7 +213,7 @@ const ConfigurationPage = () => {
         )}
 
         <div className="settings-section-title--spaced">
-          Habilitación de Funcionalidades
+          Habilitación de Funcionalidades :
         </div>
 
         {error && <p className="settings-error-text">{error}</p>}

--- a/Web Ui/src/sections/Settings/components/EditPromptAI.tsx
+++ b/Web Ui/src/sections/Settings/components/EditPromptAI.tsx
@@ -26,21 +26,23 @@ const EditPromptAI = ({
   const handleClear = () => setValue("");
 
   return (
-    <Box sx={{ mt: 4, mb: 8, p: 2, background: "#fff", borderRadius: 2, boxShadow: 1 }}>
+    <Box sx={{ mt: 4, mb: 8 }}>
       {!isEditing ? (
         <>
-          <TextField
-            value={initialPrompt}
-            multiline
-            fullWidth
-            InputProps={{
-              readOnly: true,
-              inputProps: { className: "prompt-input-readonly" }
-            }}
-            variant="outlined"
-            minRows={8}
-            maxRows={16}
-          />
+          <Box sx={{ p: 2, background: "#fff", borderRadius: 2, boxShadow: 1 }}>
+            <TextField
+              value={initialPrompt}
+              multiline
+              fullWidth
+              InputProps={{
+                readOnly: true,
+                inputProps: { className: "prompt-input-readonly" }
+              }}
+              variant="outlined"
+              minRows={8}
+              maxRows={16}
+            />
+          </Box>
           <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 1 }}>
             <Button 
               className="btn-std btn-primary" 
@@ -52,16 +54,18 @@ const EditPromptAI = ({
         </>
       ) : (
         <>
-          <TextField
-            value={value}
-            onChange={e => setValue(e.target.value)}
-            multiline
-            fullWidth
-            variant="outlined"
-            minRows={8}
-            maxRows={16}
-            autoFocus
-          />
+          <Box sx={{ p: 2, background: "#fff", borderRadius: 2, boxShadow: 1 }}>
+            <TextField
+              value={value}
+              onChange={e => setValue(e.target.value)}
+              multiline
+              fullWidth
+              variant="outlined"
+              minRows={8}
+              maxRows={16}
+              autoFocus
+            />
+          </Box>
           <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 1 }}>
             <Button 
               className="btn-std btn-primary" 

--- a/Web Ui/src/sections/Settings/components/EditPromptAI.tsx
+++ b/Web Ui/src/sections/Settings/components/EditPromptAI.tsx
@@ -66,7 +66,7 @@ const EditPromptAI = ({
               autoFocus
             />
           </Box>
-          <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 1 }}>
+          <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 4 }}>
             <Button 
               className="btn-std btn-primary" 
               onClick={() => onSave(value)}

--- a/Web Ui/src/sections/Settings/components/EditPromptAI.tsx
+++ b/Web Ui/src/sections/Settings/components/EditPromptAI.tsx
@@ -43,7 +43,7 @@ const EditPromptAI = ({
               maxRows={16}
             />
           </Box>
-          <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 1 }}>
+          <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 4 }}>
             <Button 
               className="btn-std btn-primary" 
               onClick={onEdit}

--- a/Web Ui/src/sections/Shared/Components/ConfirmationDialog.tsx
+++ b/Web Ui/src/sections/Shared/Components/ConfirmationDialog.tsx
@@ -15,6 +15,7 @@ interface ConfirmationDialogProps {
   deleteText: string;
   onCancel: () => void;
   onDelete: () => void;
+  confirmButtonClassName?: string;
 }
 
 export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
@@ -25,6 +26,7 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
   deleteText,
   onCancel,
   onDelete,
+  confirmButtonClassName = "btn-danger",
 }) => {
   return (
     <Dialog open={open} onClose={onCancel} maxWidth="xs" fullWidth>
@@ -48,7 +50,7 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
 
         <Button
           onClick={onDelete}
-          className="btn-std btn-danger"
+          className={`btn-std ${confirmButtonClassName}`}
         >
           {deleteText}
         </Button>


### PR DESCRIPTION
- Se rediseno la seccion de ajustes para que el bloque de habilitación de funcionalidades quede alineado al mockup, con lista limpia y checkbox estilizado.
- Se ajusto el modulo de prompt para separar el boton Editar Prompt del cuadro blanco y dejar el campo con fondo blanco.
- Se reemplaza la confirmación nativa del navegador por un modal consistente con el sistema.
- Se unifico el feedback de exito de habilitar/deshabilitar usando el patron de dialogos ya existente, con mensajes cortos: Se habilito / Se deshabilito


<img width="547" height="344" alt="Screenshot 2026-05-02 at 4 35 11 PM" src="https://github.com/user-attachments/assets/bd51bfa6-fd92-467c-8e2a-814e2be0b541" />




<img width="1205" height="539" alt="Screenshot 2026-05-02 at 4 35 26 PM" src="https://github.com/user-attachments/assets/434e09c8-b336-46f8-8975-5455a033136a" />



<img width="1209" height="660" alt="Screenshot 2026-05-02 at 4 35 42 PM" src="https://github.com/user-attachments/assets/d9294176-ec6c-4b39-bc5f-1d893736e4af" />



<img width="874" height="450" alt="Screenshot 2026-05-02 at 4 36 51 PM" src="https://github.com/user-attachments/assets/cacc8c21-d198-4808-b510-93b9d05b10f9" />



<img width="270" height="84" alt="Screenshot 2026-05-02 at 4 37 44 PM" src="https://github.com/user-attachments/assets/ddd606de-472b-4843-98a5-c81d3f14cecc" />


