### PR TITLE
fix(ci): corregir proyecto Firebase en deploy

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -252,7 +252,7 @@ jobs:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
         run: |
-          firebase deploy --only hosting:staging
+          firebase deploy --project staging --only hosting:staging
   deploy_firebase_production:
     runs-on: ubuntu-latest
     environment:
@@ -301,7 +301,7 @@ jobs:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
         run: |
-          firebase deploy --only hosting:production
+          firebase deploy --project production --only hosting:production
   deploy_vercel_staging:
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
# fix(ci): corregir proyecto Firebase en deploy

## Resumen

Este PR ajusta el deploy de Firebase Hosting para que cada ambiente use explícitamente su proyecto correspondiente.

## Problema

El workflow ejecutaba `firebase deploy --only hosting:staging`.

Ese comando indica el target `staging`, pero no indica el proyecto Firebase. Por eso Firebase CLI usaba el proyecto `default` de `Web Ui/.firebaserc`: `tddlab-hosting-firebase`.

En el log se veía `=== Deploying to 'tddlab-hosting-firebase'...`, aunque el job era de staging. Luego fallaba con `could not find site "****" for project "tddlab-hosting-firebase"`.

## Solución

Se hizo explícito el proyecto Firebase para cada ambiente usando los aliases ya definidos en `.firebaserc`.

Antes: `firebase deploy --only hosting:staging` y `firebase deploy --only hosting:production`.

Ahora: `firebase deploy --project staging --only hosting:staging` y `firebase deploy --project production --only hosting:production`.

Con esto, staging debería desplegar en `tddlab-staging-firebase` y producción en `tddlab-hosting-firebase`.

## Si vuelve a fallar

Si el deploy sigue fallando, ya no sería por código de la app, sino por configuración externa: permisos del `FIREBASE_TOKEN`, secrets de GitHub Actions, existencia del site en Firebase Hosting o targets de `.firebaserc`.

## Validación

Este cambio solo modifica el workflow de CI/CD. No toca frontend ni backend.