### PR TITLE
fix(landing): corregir desplazamiento del botón al hacer click

### DIFF
--- a/Web Ui/src/presentation/landing/styles/Landing.css
+++ b/Web Ui/src/presentation/landing/styles/Landing.css
@@ -114,6 +114,7 @@
   left: 50%;
   top: 394px;
   transform: translateX(-50%);
+  --action-button-active-transform: translateX(-50%) scale(0.98);
   width: 202px;
   min-height: 44px;
   padding: 10px;

--- a/Web Ui/src/shared/components/ActionButton.tsx
+++ b/Web Ui/src/shared/components/ActionButton.tsx
@@ -41,7 +41,7 @@ const StyledActionButton = styled(Button, {
     },
   },
   "&:active": {
-    transform: "scale(0.98)",
+    transform: "var(--action-button-active-transform, scale(0.98))",
   },
 }));
 


### PR DESCRIPTION
## Resumen

Este PR corrige un bug visual en la landing donde el botón `Ir a TDD Lab` se desplazaba al hacer click.

## Problema

El botón de la landing está centrado con `transform: translateX(-50%)`.

Sin embargo, el componente compartido `ActionButton` aplica `transform: scale(0.98)` en el estado `:active`. Al hacer click, ese `transform` reemplazaba el `translateX(-50%)`, provocando que el botón perdiera su centrado y se moviera visualmente.

## Solución

Se ajustó `ActionButton` para permitir personalizar el transform del estado activo mediante una variable CSS.

Luego, en la landing, se definió esa variable para conservar el centrado durante el click:

`translateX(-50%) scale(0.98)`

De esta forma, el botón mantiene su posición y solo conserva el efecto visual de presión.